### PR TITLE
Use wd-player rather than direct video

### DIFF
--- a/resources/js/Pages/Welcome.tsx
+++ b/resources/js/Pages/Welcome.tsx
@@ -71,6 +71,9 @@ export default function Welcome({ defaultLang = 'en' }: WelcomeProps) {
   // Fetch stats on page load.
   useEffect(() => {
     loadStats();
+
+    // @ts-ignore
+    window.wdplayer('#player');
   }, []);
 
   return (
@@ -100,7 +103,8 @@ export default function Welcome({ defaultLang = 'en' }: WelcomeProps) {
 
         <div className="mx-auto w-full max-w-5xl px-3">
           <div className="relative">
-            <video
+            <video id="player" />
+            {/* <video
               autoPlay
               muted
               className="aspect-video w-full"
@@ -114,7 +118,7 @@ export default function Welcome({ defaultLang = 'en' }: WelcomeProps) {
                 type="video/mp4"
               />
               Your browser does not support the video tag.
-            </video>
+            </video> */}
             {loading && (
               <p className="absolute inset-0 flex h-full w-full items-center justify-center bg-black text-white">
                 Loading...
@@ -131,7 +135,7 @@ export default function Welcome({ defaultLang = 'en' }: WelcomeProps) {
             </p>
           </div>
           <div className="relative mt-4 flex">
-            <Select
+            {/* <Select
               defaultValue={lang}
               label="Language"
               onValueChange={handleLangChange}
@@ -140,7 +144,7 @@ export default function Welcome({ defaultLang = 'en' }: WelcomeProps) {
               <Option value="fr">French</Option>
               <Option value="de">German</Option>
               <Option value="it">Italian</Option>
-            </Select>
+            </Select> */}
 
             <Dialog
               lang={lang}

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -48,6 +48,7 @@
     </noscript>
 
     <!-- Styles -->
+    <link rel="stylesheet" href="https://embed.watchdominion.org/dist/wd-player.css" />
     <link rel="stylesheet" href="{{ mix('css/app.css') }}" />
 
     <!-- Scripts -->
@@ -67,6 +68,7 @@
 
     @routes
     <script src="{{ mix('js/app.js') }}" defer></script>
+    <script src="https://embed.watchdominion.org/dist/wd-player.umd.js"></script>
 
     @inertiaHead
   </head>


### PR DESCRIPTION
This code change is only meant as a way to test out the new player. There's still some work to be done in order to fully embed the player:
- Load wd-player script in a non-blocking way (improving performance).
- Remove the language switching capabilities (including routes), or find a way to select the preferred audio source.
- Have a fallback in place for when the player fails for whatever reason.
- Update the embed dialog to point to https://embed.watchdominion.org, if people are interested in embedding Dominion on their site.
- Probably more things I can't remember right now.