### PR TITLE
Update Game Changers link

### DIFF
--- a/resources/js/Pages/Welcome.tsx
+++ b/resources/js/Pages/Welcome.tsx
@@ -307,7 +307,7 @@ export default function Welcome({ defaultLang = 'en' }: WelcomeProps) {
                 as="externalLink"
                 variant="secondary"
                 className="group mt-6"
-                href="https://www.netflix.com/id-en/title/81157840"
+                href="https://gamechangersmovie.com"
                 data-click="redirect-game-changers"
               >
                 <span className="mr-6">Game Changers</span>


### PR DESCRIPTION
Game Changers is no longer available on Netflix, so I've updated the link to point to the Game Changers website for the time being.