### PR TITLE
Add on-page SEO metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,9 +9,7 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="canonical" href="%VITE_APP_URL%/" />
 
-    <title>
-      Watch the award-winning and life changing documentary, Dominion!
-    </title>
+    <title>Watch Dominion (2018) — Full Documentary, Free</title>
     <meta
       name="description"
       content="Dominion uses drones, hidden and handheld cameras to expose the dark underbelly of modern animal agriculture, questioning the morality and validity of humankind's dominion over the animal kingdom."

--- a/index.html
+++ b/index.html
@@ -50,6 +50,8 @@
         "name": "Dominion",
         "url": "%VITE_APP_URL%/",
         "image": "%VITE_APP_URL%/img/watchdominion.jpg",
+        "thumbnailUrl": "%VITE_APP_URL%/img/watchdominion.jpg",
+        "genre": "Documentary",
         "description": "Dominion uses drones, hidden and handheld cameras to expose the dark underbelly of modern animal agriculture, questioning the morality and validity of humankind's dominion over the animal kingdom.",
         "director": { "@type": "Person", "name": "Chris Delforce" },
         "dateCreated": "2018",
@@ -60,6 +62,27 @@
           "@type": "WatchAction",
           "target": "%VITE_APP_URL%/"
         }
+      }
+    </script>
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "VideoObject",
+        "name": "Dominion",
+        "description": "Dominion uses drones, hidden and handheld cameras to expose the dark underbelly of modern animal agriculture, questioning the morality and validity of humankind's dominion over the animal kingdom.",
+        "thumbnailUrl": "%VITE_APP_URL%/img/watchdominion.jpg",
+        "uploadDate": "2018-10-09",
+        "duration": "PT1H59M59S",
+        "inLanguage": "en",
+        "embedUrl": "https://player.mediadelivery.net/embed/135301/89232d42-e290-40fc-917d-5669478ee73b",
+        "sameAs": [
+          "https://www.youtube.com/watch?v=LQRAfJyEsko",
+          "https://www.youtube.com/watch?v=V7DrljVAaYk",
+          "https://www.youtube.com/watch?v=4yLbg1DvgBU",
+          "https://www.youtube.com/watch?v=sGov7OJDDO0",
+          "https://www.youtube.com/watch?v=QlaiMB3dobA"
+        ]
       }
     </script>
 

--- a/index.html
+++ b/index.html
@@ -95,6 +95,26 @@
   </head>
 
   <body class="bg-dark text-white">
+    <noscript>
+      <div class="mx-auto max-w-2xl space-y-4 p-8">
+        <h1 class="text-3xl font-black uppercase text-accent">
+          Watch Dominion
+        </h1>
+        <p>
+          Dominion uses drones, hidden and handheld cameras to expose the dark
+          underbelly of modern animal agriculture, questioning the morality and
+          validity of humankind's dominion over the animal kingdom.
+        </p>
+        <p>
+          This site needs JavaScript to play the film. You can also
+          <a
+            class="font-semibold underline"
+            href="https://www.youtube.com/watch?v=LQRAfJyEsko"
+            >watch Dominion on YouTube</a
+          >.
+        </p>
+      </div>
+    </noscript>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -47,6 +47,20 @@ describe("visitor stats", () => {
   });
 });
 
+describe("page metadata", () => {
+  beforeEach(() => {
+    fetchMock.mockResolvedValue(statsResponse({ visitors: 1 }));
+  });
+
+  it("names the film in the heading", () => {
+    render(<App />);
+
+    expect(screen.getByRole("heading", { level: 1 }).textContent).toContain(
+      "Dominion",
+    );
+  });
+});
+
 describe("share", () => {
   const clickShare = () =>
     fireEvent.click(screen.getByText("Tap here to share!"));

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -59,6 +59,12 @@ describe("page metadata", () => {
       "Dominion",
     );
   });
+
+  it("marks the document language", () => {
+    render(<App />);
+
+    expect(document.documentElement.lang).toBe("en");
+  });
 });
 
 describe("share", () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,6 +91,10 @@ function App() {
     [],
   );
 
+  useEffect(() => {
+    document.documentElement.lang = lang;
+  }, [lang]);
+
   // Fetch stats on page load.
   useEffect(() => {
     fetch("https://visitors.watchdominion.org")

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,14 +108,16 @@ function App() {
       <div className="relative flex flex-col">
         <div className="mx-auto grid w-full max-w-5xl grid-cols-1 items-center py-12 lg:grid-cols-2">
           <div className="flex flex-col space-y-4 p-16">
-            <h1 className="flex flex-col text-center text-7xl font-black uppercase text-beige lg:text-8xl">
-              <span className="text-accent">Watch</span>
-              <span>this</span>
-              <span>movie</span>
+            <h1 className="flex flex-col space-y-4">
+              <span className="flex flex-col text-center text-7xl font-black uppercase text-beige lg:text-8xl">
+                <span className="text-accent">Watch</span> <span>this</span>{" "}
+                <span>movie</span>
+              </span>{" "}
+              <span className="flex flex-col space-y-2 text-center font-rock text-xl uppercase text-accent lg:text-3xl">
+                <span>Dominion</span>{" "}
+                <span className="whitespace-nowrap">It's life changing !</span>
+              </span>
             </h1>
-            <h2 className="whitespace-nowrap text-center font-rock text-xl uppercase text-accent lg:text-3xl">
-              It's life changing !
-            </h2>
           </div>
           <div className="hidden lg:block">
             <picture>


### PR DESCRIPTION
`uploadDate` on the new `VideoObject` is sourced from the English YouTube listing, not the Bunny stream — noted in that commit's body.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added enhanced page metadata for the documentary, including thumbnail, genre, video details, and alternate playback links.
  - Added a no-JavaScript fallback with the documentary title, description, and viewing link.
  - Updated the hero heading with the full film title and tagline.
  - Page language now updates automatically when users switch languages.

- **Tests**
  - Added coverage for the page title heading and English language metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->